### PR TITLE
 Change carbon.governance version to 4.7.22 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1068,7 +1068,7 @@
         <carbon.registry.imp.pkg.version>[4.6.0, 5.0.0)</carbon.registry.imp.pkg.version>
 
         <!-- Carbon Governance version comes here-->
-        <carbon.governance.version>4.7.21</carbon.governance.version>
+        <carbon.governance.version>4.7.22</carbon.governance.version>
         <carbon.governance.imp.pkg.version>[4.7.0, 5.0.0)</carbon.governance.imp.pkg.version>
 
         <carbon.mediation.version>4.4.0</carbon.mediation.version>


### PR DESCRIPTION
## Purpose
Changing carbon.governance version to 4.7.22 
## Goals
Moving to the latest released carbon-governance version

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
N/A

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 1.7
 
## Learning
N/A
  