### PR TITLE
Jacoco plugin integration

### DIFF
--- a/components/governance-extensions/org.wso2.carbon.governance.soap.viewer/pom.xml
+++ b/components/governance-extensions/org.wso2.carbon.governance.soap.viewer/pom.xml
@@ -150,6 +150,14 @@
                     </instructions>
                 </configuration>
             </plugin>
+	    <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
 
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,40 @@
                         </execution>
                     </executions>
                 </plugin>
+		<plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                            <configuration>
+                                <propertyName>argLine</propertyName>
+                                <destFile>${project.build.directory}/jacoco.exec</destFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-report-by-coverage-enforcer</id>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                            <configuration>
+                                <dataFile>${project.build.directory}/jacoco.exec</dataFile>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.21.0</version>
+                    <configuration>
+                        <argLine>${argLine}</argLine>
+                    </configuration>
+                </plugin>
 
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## Purpose
Generate unit test coverage information

## Goals
Integrate Jacoco Maven plugin with Maven Surefire plugin to generate unit test coverage information